### PR TITLE
Fix issues on Android devices

### DIFF
--- a/android/src/main/java/com/example/sim_data/SimDataPlugin.java
+++ b/android/src/main/java/com/example/sim_data/SimDataPlugin.java
@@ -185,37 +185,40 @@ public class SimDataPlugin implements FlutterPlugin, MethodCallHandler, Activity
         PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
       );
 
-
-      context.registerReceiver(
-        new BroadcastReceiver() {
-          @Override
-          public void onReceive(Context context, Intent intent) {
+    BroadcastReceiver sentReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
             int res = getResultCode();
-            if(res == Activity.RESULT_OK){
-              Toast.makeText(context, "SMS Sent", Toast.LENGTH_SHORT).show();
-            }else{
-              Toast.makeText(context, "SMS not sent. Something went wrong!", Toast.LENGTH_SHORT).show();
+            if (res == Activity.RESULT_OK) {
+                Toast.makeText(context, "SMS Sent", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(context, "SMS not sent. Something went wrong!", Toast.LENGTH_SHORT).show();
             }
-          }
-        },
-        new IntentFilter(sent),
-        Context.RECEIVER_EXPORTED
-      );
+        }
+    };
 
-      context.registerReceiver(
-        new BroadcastReceiver() {
-          @Override
-          public void onReceive(Context context, Intent intent) {
+    BroadcastReceiver deliveredReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
             int res = getResultCode();
-            if(res == Activity.RESULT_OK){
-              Toast.makeText(context, "SMS delivered", Toast.LENGTH_SHORT).show();
-            }else{
-              Toast.makeText(context, "SMS not delivered", Toast.LENGTH_SHORT).show();
+            if (res == Activity.RESULT_OK) {
+                Toast.makeText(context, "SMS delivered", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(context, "SMS not delivered", Toast.LENGTH_SHORT).show();
             }
-          }
-        }, new IntentFilter(delivered),
-        Context.RECEIVER_EXPORTED
-      );
+        }
+    };
+
+    IntentFilter sentFilter = new IntentFilter(sent);
+    IntentFilter deliveredFilter = new IntentFilter(delivered);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        context.registerReceiver(sentReceiver, sentFilter, Context.RECEIVER_EXPORTED);
+        context.registerReceiver(deliveredReceiver, deliveredFilter, Context.RECEIVER_EXPORTED);
+    } else {
+        context.registerReceiver(sentReceiver, sentFilter);
+        context.registerReceiver(deliveredReceiver, deliveredFilter);
+    }
 
       smsManager.sendTextMessage(number, null, message, sendPendingIntent, deliveryPendingIntent);
   }

--- a/lib/sim_data_model.dart
+++ b/lib/sim_data_model.dart
@@ -39,10 +39,10 @@ class SimDataModel {
   ///Parses the json data into SimDataModel
   factory SimDataModel.fromJson(Map<String, dynamic> json) => SimDataModel(
         carrierName: json['CARRIER_NAME'] ?? "",
-        isESIM: json['IS_EMBEDDED'] ?? "",
-        subscriptionId: json['SUBSCRIPTION_ID'] ?? "",
-        simSlotIndex: json['SIM_SLOT_INDEX'] ?? "",
-        cardId: json['CARD_ID'] ?? "",
+        isESIM: json['IS_EMBEDDED'] ?? false,
+        subscriptionId: json['SUBSCRIPTION_ID'] ?? 0,
+        simSlotIndex: json['SIM_SLOT_INDEX'] ?? 0,
+        cardId: json['CARD_ID'] ?? 0,
         phoneNumber: json['PHONE_NUMBER'] ?? "",
         displayName: json['DISPLAY_NAME'] ?? "",
         countryCode: json['COUNTRY_CODE'] ?? "",


### PR DESCRIPTION
1. Fix null safety in SimDataModel
The default values of the fields in `fromJson` were of the wrong types and caused a crash if non-string fields were null.

2. Fix broadcast receivers crash on Android <12
The broadcast receivers were registered with the `RECEIVER_EXPORTED` flag, which caused a crash on Android devices with SDK versions lower than 31.